### PR TITLE
Running wii-u-gc-adapter in the background with udev rule and script

### DIFF
--- a/88-wii-u-gamecube-adapter.rules
+++ b/88-wii-u-gamecube-adapter.rules
@@ -1,0 +1,8 @@
+# This is some custom rules for udev to start a certain program when it detects
+# a Wii U Gamecube adapter.  Sadly, it currently doesn't work.
+# - Jason Anderson, December 12, 2014
+
+# I found this trick for running a script like this from this website:
+# http://askubuntu.com/questions/395733/automatically-disable-mouse-acceleration-whenever-mouse-is-plugged
+# - Jason Anderson, September 18, 2015
+SUBSYSTEM=="usb", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="0337", MODE="0666", GROUP="uinput", SYMLINK+="input/wii-u-gc-adapter", RUN+="/usr/local/bin/run-wii-u-setup.sh"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,6 @@ Section "InputClass"
 EndSection
 ````
 
-To properly run wii-u-gc-adapter when the adapter is plugged in, the following files have to be placed in certain places.
+To properly run wii-u-gc-adapter when the adapter is plugged in, the following files have to be placed in certain directories.
 
 The file `88-wii-u-gamecube-adapter.rules` should be placed in `/etc/udev/rulles.d/`.  This file starts the script, `run-wii-u-setup.sh`, when the adapter is connected.  This script, in turn, runs the script `start-wii-u-adapter.sh`, and starts `wii-u-gc-adapter` in the background.  Both of these scripts should be made executable (`chmod +x run-wii-u-setup.sh start-wii-u-adapter.sh`) and placed in `/usr/local/bin/`.  With these files in place, along with the above xorg.conf rule, the Wii U Gamecube adapter should work.

--- a/README.md
+++ b/README.md
@@ -40,3 +40,7 @@ Section "InputClass"
         Option "Ignore" "on"
 EndSection
 ````
+
+To properly run wii-u-gc-adapter when the adapter is plugged in, the following files have to be placed in certain places.
+
+The file `88-wii-u-gamecube-adapter.rules` should be placed in `/etc/udev/rulles.d/`.  This file starts the script, `run-wii-u-setup.sh`, when the adapter is connected.  This script, in turn, runs the script `start-wii-u-adapter.sh`, and starts `wii-u-gc-adapter` in the background.  Both of these scripts should be made executable (`chmod +x run-wii-u-setup.sh start-wii-u-adapter.sh`) and placed in `/usr/local/bin/`.  With these files in place, along with the above xorg.conf rule, the Wii U Gamecube adapter should work.

--- a/run-wii-u-setup.sh
+++ b/run-wii-u-setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+export DISPLAY=$(DISPLAY)
+/usr/local/bin/start-wii-u-adapter.sh &

--- a/start-wii-u-adapter.sh
+++ b/start-wii-u-adapter.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
-
-/usr/local/bin/wii-u-gc-adapter &
+# This is just in case the user plugs in the Wii U Gamecube Adapter with wii-u-gc-adapter already running.
+if [ ! "$(pidof wii-u-gc-adapter)" ]; then
+   /usr/local/bin/wii-u-gc-adapter &
+fi

--- a/start-wii-u-adapter.sh
+++ b/start-wii-u-adapter.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/local/bin/wii-u-gc-adapter &


### PR DESCRIPTION
I may have figured out a way to run wii-u-gc-adapter in the background when the user plugs in the Wii U Gamecube Adapter.  Usually, udev can't be bothered with running a daemon in the background.  Therefore, a udev rule could run a script, which runs *another* script, and that script runs wii-u-gc-adapter in the background.