### PR TITLE
Fixed write if less than all pending bytes were written in one operation

### DIFF
--- a/wii-u-gc-adapter.c
+++ b/wii-u-gc-adapter.c
@@ -349,8 +349,16 @@ static void handle_payload(int i, struct ports *port, unsigned char *payload, st
       events[e_count].type = EV_SYN;
       events[e_count].code = SYN_REPORT;
       e_count++;
-      if (write(port->uinput, events, sizeof(events[0]) * e_count) != (int)sizeof(events[0]) * e_count)
-         fprintf(stderr, "Warning: writing input events failed\n");
+      size_t to_write = sizeof(events[0]) * e_count;
+      size_t written = 0;
+      while (written < to_write) {
+         ssize_t write_ret = write(port->uinput, (const char*)events + written, to_write - written);
+         if (write_ret <= 0) {
+            fprintf(stderr, "Warning: writing input events failed, return value was %d\n", write_ret);
+            break;
+         }
+         written += write_ret;
+      }
    }
 
    // check for rumble events

--- a/wii-u-gc-adapter.c
+++ b/wii-u-gc-adapter.c
@@ -15,6 +15,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <signal.h>
+#include <errno.h>
 
 #include <libudev.h>
 #include <libusb.h>
@@ -351,10 +352,14 @@ static void handle_payload(int i, struct ports *port, unsigned char *payload, st
       e_count++;
       size_t to_write = sizeof(events[0]) * e_count;
       size_t written = 0;
-      while (written < to_write) {
+      while (written < to_write)
+      {
          ssize_t write_ret = write(port->uinput, (const char*)events + written, to_write - written);
-         if (write_ret <= 0) {
-            fprintf(stderr, "Warning: writing input events failed, return value was %d\n", write_ret);
+         if (write_ret < 0)
+         {
+            char msg[128];
+            strerror_r(errno, msg, sizeof(msg));
+            fprintf(stderr, "Warning: writing input events failed: %s\n", msg);
             break;
          }
          written += write_ret;


### PR DESCRIPTION
When I run the program, I get a lot of "Warning: writing input events failed" when I touch any button or stick on my controller but no events are received by my games.

I figured out the write code to uinput is not correct. This patch makes sure all data is written even if all data couldn't be written in a single write command.

This should fix #23.