### PR TITLE
Add new argument --relative to make a default sitck value = 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Quirks
 * Input ranges on the sticks/analog triggers are scaled to try to match the
   physical ranges of the controls. To remove this scaling run the program with
   the `--raw` flag.
+* If needed to make sticks work in the range from -128 to 128 use the `--relative` flag. In can be handy if a contoller used in rpcs3 emulator
 * If all your controllers start messing with the mouse cursor, you can fix
   them with this xorg.conf rule. (You can place it in a file in xorg.conf.d)
 

--- a/wii-u-gc-adapter.c
+++ b/wii-u-gc-adapter.c
@@ -96,6 +96,8 @@ struct adapter
 
 static bool raw_mode;
 
+static bool relative_mode;
+
 static volatile int quitting;
 
 static struct adapter adapters;
@@ -154,6 +156,16 @@ static bool uinput_create(int i, struct ports *port, unsigned char type)
       uinput_dev.absmin[ABS_RY] = 0;  uinput_dev.absmax[ABS_RY] = 255;
       uinput_dev.absmin[ABS_Z]  = 0;  uinput_dev.absmax[ABS_Z]  = 255;
       uinput_dev.absmin[ABS_RZ] = 0;  uinput_dev.absmax[ABS_RZ] = 255;
+   }
+   else if (relative_mode)
+   {
+    // In relative mode count from 0
+      uinput_dev.absmin[ABS_X]  = -95;  uinput_dev.absmax[ABS_X]  = 95;
+      uinput_dev.absmin[ABS_Y]  = -95;  uinput_dev.absmax[ABS_Y]  = 95;
+      uinput_dev.absmin[ABS_RX] = -95;  uinput_dev.absmax[ABS_RX] = 95;
+      uinput_dev.absmin[ABS_RY] = -95;  uinput_dev.absmax[ABS_RY] = 95;
+      uinput_dev.absmin[ABS_Z]  = 0;  uinput_dev.absmax[ABS_Z]  = 255;
+      uinput_dev.absmin[ABS_RZ] = 0;  uinput_dev.absmax[ABS_RZ] = 255;       
    }
    else
    {
@@ -333,7 +345,7 @@ static void handle_payload(int i, struct ports *port, unsigned char *payload, st
 
    for (int j = 0; j < 6; j++)
    {
-      unsigned char value = payload[j+3];
+    int value = payload[j+3];
 
       if (AXIS_OFFSET_VALUES[j] == ABS_Y || AXIS_OFFSET_VALUES[j] == ABS_RY)
          value ^= 0xFF; // flip from 0 - 255 to 255 - 0
@@ -342,6 +354,10 @@ static void handle_payload(int i, struct ports *port, unsigned char *payload, st
       {
          events[e_count].type = EV_ABS;
          events[e_count].code = AXIS_OFFSET_VALUES[j];
+         // only analog sticks can have negative values, triggers cannot
+         if (relative_mode && AXIS_OFFSET_VALUES[j] != ABS_Z && AXIS_OFFSET_VALUES[j] != ABS_RZ) {
+             value = value - 132;
+         }
          events[e_count].value = value;
          e_count++;
          port->axis[j] = value;
@@ -583,10 +599,15 @@ int main(int argc, char *argv[])
 
    memset(&sa, 0, sizeof(sa));
 
-   if (argc > 1 && (strcmp(argv[1], "-r") == 0 || strcmp(argv[1], "--raw") == 0))
-   {
-      fprintf(stderr, "raw mode enabled\n");
-      raw_mode = true;
+   if (argc > 1){
+      if (strcmp(argv[1], "-r") == 0 || strcmp(argv[1], "--raw") == 0){
+         fprintf(stderr, "raw mode enabled\n");
+         raw_mode = true;
+      } else if (strcmp(argv[1], "-R") == 0 || strcmp(argv[1], "--relative") == 0){
+         fprintf(stderr, "relative mode enabled\n");
+         relative_mode = true;  
+       }
+       
    }
 
    sa.sa_handler = quitting_signal;


### PR DESCRIPTION
With an argument --relative values for sticks will be from -128 to 128. I wasn't able to dash in Scott Pilgrim in rpcs3, so made that option available.
I'm not a C developer, made my changes by your example, so feel free to refactor my code and change parts